### PR TITLE
Prepare version to 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Version 0.9.0
 **2024-07-11**
 
-- Support to macOS - #22 - @joaolfp
+- Support for macOS - #22 - @joaolfp
 - Update Rust crate clap to v4.5.8 - #21 - @renovatebot
 
 ## Version 0.8.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## Version 0.9.0
+**2024-07-11**
+
+- Support to macOS - #22 - @joaolfp
+- Update Rust crate clap to v4.5.8 - #21 - @renovatebot
+
 ## Version 0.8.0
 **2024-06-18**
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -761,7 +761,7 @@ checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
 
 [[package]]
 name = "xrun"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "clap",
  "colored",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xrun"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 authors = ["João Lucas <joaolucasfp2001@gmail.com>"]
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ xrun workspace DeliveryApp.xcworkspace DeliveryApp macOS generate-file
    U /  \ u  |  _ <    | |_| |U| |\  |u
     /_/\_\   |_| \_\  <<\___/  |_| \_|
   ,-,>> \\_  //   \\_(__) )(   ||   \\,-.
-   \_)  (__)(__)  (__)   (__)  (_")  (_/  (0.8.0)
+   \_)  (__)(__)  (__)   (__)  (_")  (_/  (0.9.0)
 
 💻 https://github.com/heroesofcode/xrun
 ===================================================

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,7 +3,7 @@
 ## Version 0.9.0
 **2024-07-11**
 
-- Support to macOS - #22 - @joaolfp
+- Support for macOS - #22 - @joaolfp
 - Update Rust crate clap to v4.5.8 - #21 - @renovatebot
 
 ## Version 0.8.0

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Version 0.9.0
+**2024-07-11**
+
+- Support to macOS - #22 - @joaolfp
+- Update Rust crate clap to v4.5.8 - #21 - @renovatebot
+
 ## Version 0.8.0
 **2024-06-18**
 

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -104,7 +104,7 @@ xrun workspace DeliveryApp.xcworkspace DeliveryApp macOS generate-file
    U /  \ u  |  _ <    | |_| |U| |\  |u
     /_/\_\   |_| \_\  <<\___/  |_| \_|
   ,-,>> \\_  //   \\_(__) )(   ||   \\,-.
-   \_)  (__)(__)  (__)   (__)  (_")  (_/  (0.8.0)
+   \_)  (__)(__)  (__)   (__)  (_")  (_/  (0.9.0)
 
 💻 https://github.com/heroesofcode/xrun
 ===================================================

--- a/src/header.rs
+++ b/src/header.rs
@@ -11,7 +11,7 @@ pub fn header() {
    U /  \ u  |  _ <    | |_| |U| |\  |u   
     /_/\_\   |_| \_\  <<\___/  |_| \_|    
   ,-,>> \\_  //   \\_(__) )(   ||   \\,-. 
-   \_)  (__)(__)  (__)   (__)  (_")  (_/  (0.8.0)
+   \_)  (__)(__)  (__)   (__)  (_")  (_/  (0.9.0)
     "#;
 
     println!("{}", text);
@@ -23,7 +23,7 @@ pub fn header() {
 
 fn validation_helper() {
     let _app = Command::new("xrun")
-        .version("0.8.0")
+        .version("0.9.0")
         .ignore_errors(true)
         .get_matches();
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for macOS.
  
- **Updates**
  - Version number updated to 0.9.0.
  - Updated Rust crate clap to v4.5.8.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->