### PR TITLE
feat: add rust cache github actions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -11,6 +11,12 @@ jobs:
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8
 
+      - name: Mise install
+        uses: jdx/mise-action@eb508e65f0eb73d4fc9fc9505569833136217cc9
+        with:
+          cache: true
+          experimental: true
+
       - uses: Swatinem/rust-cache@42c55942cfd355e94e6864616f4dbb3392bd2789
 
       - name: Read Xcode version
@@ -21,12 +27,6 @@ jobs:
         uses: maxim-lobanov/setup-xcode@7f352e61cbe8130c957c3bc898c4fb025784ea1e
         with:
           xcode-version: ${{ env.XCODE_VERSION }}
-
-      - name: Mise install
-        uses: jdx/mise-action@eb508e65f0eb73d4fc9fc9505569833136217cc9
-        with:
-          cache: true
-          experimental: true
 
       - name: Build
         run: mise build


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Pins CI actions to specific SHAs and adds Rust caching to speed builds.
> 
> - **CI Workflow (`.github/workflows/CI.yml`)**:
>   - Pin actions to commit SHAs: `actions/checkout`, `jdx/mise-action`, `maxim-lobanov/setup-xcode`.
>   - Add Rust cache via `Swatinem/rust-cache`.
>   - Enable caching for `mise` (`cache: true`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ffaee3752f12ebc1701e1816b9f734029b06265e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow: pinned CI actions to fixed versions for stability.
  * Reordered installation steps to run a new tool install earlier and removed a duplicate install block.
  * Added Rust/caching to speed builds.
  * Kept build, iOS example run, and test steps functionally unchanged.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->