### PR TITLE
refactor: use &mut str instead of &mut String for idiomatic API

### DIFF
--- a/src/output.rs
+++ b/src/output.rs
@@ -115,7 +115,9 @@ impl Output {
 	) {
 		let reader = BufReader::new(reader);
 		let mut last_module_printed = String::new();
-		for line in reader.lines().map_while(Result::ok) {
+
+		for line_result in reader.lines() {
+			let Ok(line) = line_result else { continue };
 			let mut mutable_line = line.clone();
 
 			Self::extract_current_module(&mutable_line, current_module);

--- a/src/output.rs
+++ b/src/output.rs
@@ -86,14 +86,14 @@ impl Output {
 	/// Processes a single line of xcodebuild output to detect test results.
 	/// Updates test counters and error collection based on pass/fail markers.
 	fn process_validation_line(
-		line: &mut String,
+		line: &mut str,
 		passed_tests: &mut u128,
 		failed_tests: &mut u128,
 		test_errors: &mut Vec<(String, String)>,
-		current_module: &mut String,
+		current_module: &mut str,
 	) {
 		// Skip lines that are just the module name itself
-		if line.trim() != current_module.as_str() {
+		if line.trim() != current_module {
 			ValidationLine::validation_lines(
 				line,
 				passed_tests,
@@ -115,7 +115,7 @@ impl Output {
 	) {
 		let reader = BufReader::new(reader);
 		let mut last_module_printed = String::new();
-		for line in reader.lines().flatten() {
+		for line in reader.lines().map_while(Result::ok) {
 			let mut mutable_line = line.clone();
 
 			Self::extract_current_module(&mutable_line, current_module);

--- a/src/validation_lines.rs
+++ b/src/validation_lines.rs
@@ -6,11 +6,11 @@ impl ValidationLine {
 	/// Parses a test result line and updates test counters.
 	/// Recognizes ✓ (pass) and ✗ (fail) markers from xcpretty output.
 	pub fn validation_lines(
-		line: &mut String,
+		line: &mut str,
 		passed_tests: &mut u128,
 		failed_tests: &mut u128,
 		test_errors: &mut Vec<(String, String)>,
-		current_module: &mut String,
+		current_module: &mut str,
 	) {
 		const PASS_MARKER: char = '✓';
 		const FAIL_MARKER: char = '✗';
@@ -26,7 +26,7 @@ impl ValidationLine {
 			*failed_tests += 1;
 			let cleaned = line.replace(FAIL_MARKER, "").trim().to_string();
 			println!("    ❌ {}", cleaned.red());
-			test_errors.push((current_module.clone(), line.clone()));
+			test_errors.push((current_module.to_owned(), line.to_owned()));
 		}
 	}
 }


### PR DESCRIPTION
## ✨ Summary

- replace `&mut String` parameters with `&mut str` in `process_validation_line` and `validation_lines` for a more idiomatic Rust API
- remove redundant `.as_str()` call now that the parameter is already `&str`
- replace `.clone()` with `.to_owned()` when pushing to `test_errors` vec, consistent with owned string conversion from a slice
- replace `flatten()` with `map_while(Result::ok)` on the lines iterator in `output.rs` for more explicit error handling

## 🔧 Type of Change

- [ ] ✨ Enhancement
- [ ] 🐞 Bug fix
- [ ] 🔐 Security fix
- [ ] 💥 Breaking change
- [ ] 🚀 New feature
- [ ] 📦 New release
- [ ] 📚 Documentation
- [x] ♻️ Refactor

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor limited to output parsing/signatures; behavior should be unchanged aside from now explicitly skipping errored lines instead of silently flattening them.
> 
> **Overview**
> Updates the test-output parsing APIs to take `&mut str` instead of `&mut String` in `Output::process_validation_line` and `ValidationLine::validation_lines`, removing redundant `.as_str()` usage and using `.to_owned()` when storing failures.
> 
> Adjusts `process_output` to iterate `BufRead::lines()` with explicit `Result` handling (instead of `flatten()`), continuing past read errors in a more intentional way.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eaf3e8355cd4facff9cd9ed699305d8b74d74c77. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal string handling in validation processing for improved memory efficiency.
  * Enhanced error handling in file reading operations to stop on first error rather than silently continuing.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/heroesofcode/xrun/pull/219)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->